### PR TITLE
Added all Mood Increments/Decrements & MVP Trigger

### DIFF
--- a/Source/Atj/data/mvp_scenario.json
+++ b/Source/Atj/data/mvp_scenario.json
@@ -50,6 +50,7 @@
                     "check": "LTorEQ",
                     "value": "2"
                 }
+            ]
         }
     ],
     "actions": [
@@ -305,7 +306,7 @@
             "tasks": [
                 {
                     "type": "behavior",
-                    "sync_time": "0.01",
+                    "sync_time": "0.1",
                     "behavior": "pick_up",
                     "target": "crossword_puzzle_1"
                 },
@@ -549,7 +550,7 @@
                 },
                 {
                     "type": "execute_action",
-                    "sync_time": "0.01",
+                    "sync_time": "0.1",
                     "action": "decrement_mood_zak_action"
                 },
                 {

--- a/Source/Atj/data/mvp_scenario.json
+++ b/Source/Atj/data/mvp_scenario.json
@@ -5,7 +5,7 @@
         "sara"
     ],
     "objects": [
-        "mens_bathroom_toilet_1", 
+        "mens_bathroom_toilet_1",
         "mens_bathroom_sink_1",
         "ladys_bathroom_toilet_1",
         "printer_1",
@@ -41,6 +41,20 @@
         "hacky_sack_club_flyer_1"
     ],
     "triggers": [
+        {
+            "name": "zach_mood_1_trigger",
+            "all_of": [
+                {
+                    "type": "npc_mood_check",
+                    "npc": "sara",
+                    "check": "LTorEQ",
+                    "value": "2"
+                }
+            ],
+            "actions": [
+                "bind_zak_to_decrement_mood_zak_routine_action"
+            ]
+        }
     ],
     "actions": [
         {
@@ -227,6 +241,66 @@
                     "routine": "debug_player_move_to_bulletin_board_1_routine"
                 }
             ]
+        },
+        {
+            "name": "increment_mood_juan_action",
+            "signals": [
+                {
+                    "type": "increment_mood",
+                    "npc": "juan",
+                    "value": 1
+                }
+            ]
+        },
+        {
+            "name": "increment_mood_zak_action",
+            "signals": [
+                {
+                    "type": "increment_mood",
+                    "npc": "zak",
+                    "value": 1
+                }
+            ]
+        },
+        {
+            "name": "increment_mood_sara_action",
+            "signals": [
+                {
+                    "type": "increment_mood",
+                    "npc": "sara",
+                    "value": 1
+                }
+            ]
+        },
+        {
+            "name": "decrement_mood_juan_action",
+            "signals": [
+                {
+                    "type": "increment_mood",
+                    "npc": "juan",
+                    "value": -1
+                }
+            ]
+        },
+        {
+            "name": "decrement_mood_sara_action",
+            "signals": [
+                {
+                    "type": "increment_mood",
+                    "npc": "sara",
+                    "value": -1
+                }
+            ]
+        },
+        {
+            "name": "decrement_mood_zak_action",
+            "signals": [
+                {
+                    "type": "increment_mood",
+                    "npc": "zal",
+                    "value": -1
+                }
+            ]
         }
     ],
     "routines": [
@@ -260,6 +334,11 @@
                     "sync_time": "0.0",
                     "behavior": "move_to",
                     "target": "mens_bathroom_toilet_1"
+                },
+                {
+                    "type": "execute_action",
+                    "sync_time": "0.1",
+                    "action": "increment_mood_juan_action"
                 },
                 {
                     "type": "behavior",
@@ -313,7 +392,7 @@
             "tasks": [
                 {
                     "type": "behavior",
-                    "sync_time": "0.0",
+                    "sync_time": "0.1",
                     "behavior": "move_to",
                     "target": "refrigerator_1_routine"
                 },
@@ -322,6 +401,11 @@
                     "sync_time": "20.0",
                     "behavior": "pick_up",
                     "target": "meeting_food_1"
+                },
+                {
+                    "type": "execute_action",
+                    "sync_time": "0.1",
+                    "action": "decrement_mood_juan_action"
                 },
                 {
                     "type": "execute_action",
@@ -376,6 +460,11 @@
                 },
                 {
                     "type": "execute_action",
+                    "sync_time": "10.0",
+                    "action": "decrement_mood_zak_action"
+                },
+                {
+                    "type": "execute_action",
                     "sync_time": "40.0",
                     "action": "bind_zak_to_break_room_eat_breakfast_routine_action"
                 }
@@ -413,6 +502,16 @@
                     "sync_time": "20.0",
                     "behavior": "move_to",
                     "target": "microwave_1"
+                },
+                {
+                    "type": "execute_action",
+                    "sync_time": "0.1",
+                    "action": "decrement_mood_sara_action"
+                },
+                {
+                    "type": "execute_action",
+                    "sync_time": "0.1",
+                    "action": "increment_mood_zak_action"
                 },
                 {
                     "type": "execute_action",
@@ -454,6 +553,11 @@
                 },
                 {
                     "type": "execute_action",
+                    "sync_time": "0.01",
+                    "action": "decrement_mood_zak_action"
+                },
+                {
+                    "type": "execute_action",
                     "sync_time": "10.0",
                     "action": "bind_zak_to_take_crossword_puzzle_into_meeting_room_routine_action"
                 }
@@ -479,6 +583,11 @@
                     "sync_time": "10.0",
                     "behavior": "move_to",
                     "target": "meeting_room_chair_2"
+                },
+                {
+                    "type": "execute_action",
+                    "sync_time": "10.0",
+                    "action": "decrement_mood_zak_action"
                 }
             ]
         },
@@ -578,6 +687,11 @@
                     "sync_time": "0.0",
                     "behavior": "move_to",
                     "target": "meeting_room_chair_1"
+                },
+                {
+                    "type": "execute_action",
+                    "sync_time": "20.",
+                    "action": "decrement_mood_sara_action"
                 }
             ]
         },

--- a/Source/Atj/data/mvp_scenario.json
+++ b/Source/Atj/data/mvp_scenario.json
@@ -50,10 +50,6 @@
                     "check": "LTorEQ",
                     "value": "2"
                 }
-            ],
-            "actions": [
-                "bind_zak_to_decrement_mood_zak_routine_action"
-            ]
         }
     ],
     "actions": [
@@ -297,7 +293,7 @@
             "signals": [
                 {
                     "type": "increment_mood",
-                    "npc": "zal",
+                    "npc": "zak",
                     "value": -1
                 }
             ]

--- a/Source/Atj/data/mvp_scenario.json
+++ b/Source/Atj/data/mvp_scenario.json
@@ -686,7 +686,7 @@
                 },
                 {
                     "type": "execute_action",
-                    "sync_time": "20.",
+                    "sync_time": "20.0",
                     "action": "decrement_mood_sara_action"
                 }
             ]


### PR DESCRIPTION
Utilizing the system that Tucker created to define when Mood shifts (either up or down) occur for each character, based on the rules laid out in the Scenario File. This does not account for Player Action, it is the default progression of the simulation if the Player does not modify anything. It also introduces the concept of Mood hitting '1' as a Value at the end of the file. 

I created a trigger for whether zak goes down his final at the bulletin board or not based on sara's emotional state. Right now, our system only supports a global definition of Mood so the trigger doesn't work as intended, it will always look for whether sara is at Mood Level '2' or not and then fire zak's routine to self-destruct. Once we have functionality to support Location AND Mood based Triggers, I'll be able to hook it up to the correct 'time' in the simulation. 

I performed a diff analysis on the text I submitted in Github and made sure everything matched my expectations before I created the pull request