### PR TITLE
Josh endgame actions

### DIFF
--- a/Source/Atj/data/mvp_scenario.json
+++ b/Source/Atj/data/mvp_scenario.json
@@ -393,6 +393,14 @@
                     "type": "end_game_failure"
                 }
             ]
+        },
+        {
+            "name": "end_game_success_action",
+            "signals": [
+                {
+                    "type": "end_game_success"
+                }
+            ]
         }
     ],
     "routines": [
@@ -702,6 +710,11 @@
                     "sync_time": "40",
                     "behavior": "move_to",
                     "target": "meeting_room_chair_3"
+                },
+                {
+                    "type": "execute_action",
+                    "sync_time": "0.1",
+                    "action": "end_game_success_action"
                 }
             ]
         },
@@ -828,6 +841,11 @@
                     "sync_time": "40.0",
                     "behavior": "move_to",
                     "target": "meeting_room_chair_1"
+                },
+                {
+                    "type": "execute_action",
+                    "sync_time": "0.1",
+                    "action": "end_game_success_action"
                 }
             ]
         },

--- a/Source/Atj/data/mvp_scenario.json
+++ b/Source/Atj/data/mvp_scenario.json
@@ -76,6 +76,48 @@
                 "bind_zak_to_zak_scenario_win_routine_action",
                 "bind_sara_to_sara_scenario_win_routine_action"
             ]
+        },
+        {
+            "name": "end_game_failure_sara",
+            "all_of": [
+                {
+                    "type": "npc_mood_check",
+                    "npc": "sara",
+                    "check": "EQ",
+                    "value": "1"
+                }
+            ],
+            "actions": [
+                "end_game_failure_action"
+            ]
+        },
+        {
+            "name": "end_game_failure_zak",
+            "all_of": [
+                {
+                    "type": "npc_mood_check",
+                    "npc": "zak",
+                    "check": "EQ",
+                    "value": "1"
+                }
+            ],
+            "actions": [
+                "end_game_failure_action"
+            ]
+        },
+        {
+            "name": "end_game_failure_juan",
+            "all_of": [
+                {
+                    "type": "npc_mood_check",
+                    "npc": "juan",
+                    "check": "EQ",
+                    "value": "1"
+                }
+            ],
+            "actions": [
+                "end_game_failure_action"
+            ]
         }
     ],
     "actions": [
@@ -341,6 +383,14 @@
                     "type": "bind_npc",
                     "npc": "sara",
                     "routine": "sara_scenario_win_routine"
+                }
+            ]
+        },
+        {
+            "name": "end_game_failure_action",
+            "signals": [
+                {
+                    "type": "end_game_failure"
                 }
             ]
         }

--- a/Source/Atj/data/mvp_scenario.json
+++ b/Source/Atj/data/mvp_scenario.json
@@ -841,11 +841,6 @@
                     "sync_time": "40.0",
                     "behavior": "move_to",
                     "target": "meeting_room_chair_1"
-                },
-                {
-                    "type": "execute_action",
-                    "sync_time": "0.1",
-                    "action": "end_game_success_action"
                 }
             ]
         },


### PR DESCRIPTION
I created the `end_game_failure_action` and added Triggers for each NPC using the following format:
```
            "name": "end_game_failure_zak",
            "all_of": [
                {
                    "type": "npc_mood_check",
                    "npc": "zak",
                    "check": "EQ",
                    "value": "1"
                }
            ],
            "actions": [
                "end_game_failure_action"
            ]
```

I then recreated this for all 3 NPCs (sara, zak & juan)

I created the `end_game_success_action` and added that to the end of both sara & zak's win routines using the following format:
                `{
                    "type": "execute_action",
                    "sync_time": "0.1",
                    "action": "end_game_success_action"
                }
            ]`

I ran the game in the simulation and now instead of the game hanging when the JSON stops sending routines it will send the Player to the start screen whenever an NPC hits 1. 

Next step is to figure out why the debug player isn't succeeding in the simulation, since it *should* complete the simulation successfully if left to its own devices. I'll be debugging that next, but that does not stop this being at a point where I want to close the branch 
