### PR TITLE
Init items in object slots

### DIFF
--- a/Source/Atj/ScenarioParser.cpp
+++ b/Source/Atj/ScenarioParser.cpp
@@ -160,6 +160,23 @@ void AScenarioParser::ParseScenario()
 			scenarioData.objects.Add(object);
 		};
 
+		// Parse items
+		TArray<TSharedPtr<FJsonValue>> items = JsonObject->GetArrayField("items");
+		for (const auto item : items)
+		{
+			auto itemObject = item->AsObject();
+			FString itemName = itemObject->GetStringField("name");
+			UE_LOG(LogTemp, Warning, TEXT("DEBUG Item: %s"), *(itemName));
+
+			FItemData fItemData;
+
+			fItemData.name = itemName;
+			fItemData.initialObject = itemObject->GetStringField("initial_object");
+
+			// Add data to struct
+			scenarioData.items.Add(itemName, fItemData);
+		};
+
 		// Parse triggers
 		TArray<TSharedPtr<FJsonValue>> triggers = JsonObject->GetArrayField("triggers");
 		for (const auto trigger : triggers)

--- a/Source/Atj/ScenarioParser.h
+++ b/Source/Atj/ScenarioParser.h
@@ -69,6 +69,18 @@ struct FCondition_ItemInObjectSlotCheck : public FCondition
 };
 
 USTRUCT(BlueprintType)
+struct FItemData
+{
+	GENERATED_USTRUCT_BODY()
+
+	UPROPERTY(BlueprintReadWrite)
+		FString name;
+
+	UPROPERTY(BlueprintReadWrite)
+		FString initialObject;
+};
+
+USTRUCT(BlueprintType)
 struct FTrigger
 {
 	GENERATED_USTRUCT_BODY()
@@ -232,6 +244,9 @@ struct FScenarioData
 
 	UPROPERTY(BlueprintReadWrite)
 		TArray<FString> npcs;
+
+	UPROPERTY(BlueprintReadWrite)
+		TMap<FString, FItemData> items;
 
 	UPROPERTY(BlueprintReadWrite)
 		TArray<FString> objects;

--- a/Source/Atj/ScenarioRunner.cpp
+++ b/Source/Atj/ScenarioRunner.cpp
@@ -394,6 +394,28 @@ void AScenarioRunner::ProcessAction(UWorld* world, const FScenarioData& scenario
 	}
 }
 
+static void InitItems(UWorld* world, const TMap<FString, FItemData>& items) {
+	ANpcCharacter* npc = FindNpcCharacter(world, "player");
+	if (!npc) {
+		UE_LOG(LogTemp, Error, TEXT("Npc does not exist: %s"), *("player"));
+		return;
+	}
+	for (const auto& itemData : items) {
+		AItemActor* item = FindItemActor(world, itemData.Value.name);
+		if (!item) {
+			UE_LOG(LogTemp, Error, TEXT("Item does not exist: %s"), *(itemData.Value.name));
+			continue;
+		}
+		AObjectActor* object = FindObjectActor(world, itemData.Value.initialObject);
+		if (!object) {
+			UE_LOG(LogTemp, Error, TEXT("Object does not exist: %s"), *(itemData.Value.initialObject));
+			continue;
+		}
+		npc->PickUp(item);
+		npc->PutDown(object);
+	}
+}
+
 void AScenarioRunner::SetScenarioData(const FScenarioData& data) {
 	_scenarioData = data;
 	constexpr int DEFAULT_MOOD_VALUE = 3;
@@ -403,6 +425,7 @@ void AScenarioRunner::SetScenarioData(const FScenarioData& data) {
 	for (const auto& trigger : _scenarioData.GetValue().triggers) {
 		_triggerState.Add(trigger.Key, false);
 	}
+	InitItems(GetWorld(), _scenarioData.GetValue().items);
 	if (data.actions.Contains("simulation_start")) {
 		ProcessAction(GetWorld(), data, "simulation_start", GetWorld()->GetTimeSeconds());
 	}

--- a/Source/Atj/data/mvp_scenario.json
+++ b/Source/Atj/data/mvp_scenario.json
@@ -30,13 +30,34 @@
         "copier_1"
     ],
     "items": [
-        "crossword_puzzle_1",
-        "big_meeting_agenda_1",
-        "meeting_food_1",
-        "hacky_sack_1",
-        "zaks_breakfast_1",
-        "saras_coffee_cup_1",
-        "hacky_sack_club_flyer_1"
+        {
+            "name": "crossword_puzzle_1",
+            "initial_object": "reception_desk_1"
+        },
+        {
+            "name": "big_meeting_agenda_1",
+            "initial_object": "printer_1"
+        },
+        {
+            "name": "meeting_food_1",
+            "initial_object": "meeting_room_table_1"
+        },
+        {
+            "name": "hacky_sack_1",
+            "initial_object": "meeting_room_chair_3"
+        },
+        {
+            "name": "zaks_breakfast_1",
+            "initial_object": "zaks_desk_1"
+        },
+        {
+            "name": "saras_coffee_cup_1",
+            "initial_object": "saras_desk_1"
+        },
+        {
+            "name": "hacky_sack_club_flyer_1",
+            "initial_object": "ladys_bathroom_toilet_1"
+        }
     ],
     "triggers": [
         {


### PR DESCRIPTION
Items are now defined with an `intial_object` specifying the object these are slotted too. This field is mandatory.
I've initialized these items at "reasonable" locations, but a revision pass should be done to place these in the correct location.

Example usage:
```
 "items": [
        {
            "name": "crossword_puzzle_1",
            "initial_object": "reception_desk_1"
        },
        {
            "name": "big_meeting_agenda_1",
            "initial_object": "printer_1"
        },
        // More items can be added
]
```