### PR TITLE
Josh evaluatetriggerupdate

### DIFF
--- a/Source/Atj/data/mvp_scenario.json
+++ b/Source/Atj/data/mvp_scenario.json
@@ -173,6 +173,17 @@
                     "object": "refrigerator_1"
                 }
             ]
+        },
+        {
+            "name": "crossword_puzzle_1_in_reception_desk_1_slot_check",
+            "always_evaluate": false,
+            "all_of": [
+                {
+                    "type": "item_in_object_slot_check",
+                    "item": "crossword_puzzle_1",
+                    "object": "reception_desk_1"
+                }
+            ]
         }
     ],
     "actions": [

--- a/Source/Atj/data/mvp_scenario.json
+++ b/Source/Atj/data/mvp_scenario.json
@@ -140,6 +140,34 @@
             "actions": [
                 "end_game_failure_action"
             ]
+        },
+        {
+            "name": "big_meeting_agenda_1_in_printer_1_slot_check",
+            "always_evaluate": false,
+            "all_of": [
+                {
+                    "type": "item_in_object_slot_check",
+                    "item": "big_meeting_agenda_1",
+                    "object": "printer_1"
+                }
+            ],
+            "actions": [
+                "end_game_failure_action"
+            ]
+        },
+        {
+            "name": "meeting_food_1_in_meeting_room_table_1_slot_check",
+            "always_evaluate": false,
+            "all_of": [
+                {
+                    "type": "item_in_object_slot_check",
+                    "item": "meeting_food_1",
+                    "object": "meeting_room_table_1"
+                }
+            ],
+            "actions": [
+                "end_game_failure_action"
+            ]
         }
     ],
     "actions": [
@@ -189,12 +217,42 @@
             ]
         },
         {
-            "name": "bind_juan_to_refrigerator_1_routine_action",
+            "name": "bind_juan_to_printer_1_big_meeting_agenda_1_true_routine_action",
             "signals": [
                 {
                     "type": "bind_npc",
                     "npc": "juan",
-                    "routine": "refrigerator_1_routine"
+                    "routine": "printer_1_big_meeting_agenda_1_true_routine"
+                }
+            ]
+        },
+        {
+            "name": "bind_juan_to_juan_double_decrement_routine_action",
+            "signals": [
+                {
+                    "type": "bind_npc",
+                    "npc": "juan",
+                    "routine": "juan_double_decrement_routine"
+                }
+            ]
+        },
+        {
+            "name": "bind_juan_to_meeting_room_table_1_routine_action",
+            "signals": [
+                {
+                    "type": "bind_npc",
+                    "npc": "juan",
+                    "routine": "meeting_room_table_1_routine"
+                }
+            ]
+        },
+        {
+            "name": "bind_juan_to_meeting_food_1_in_meeting_room_table_1_true_routine_action",
+            "signals": [
+                {
+                    "type": "bind_npc",
+                    "npc": "juan",
+                    "routine": "meeting_food_1_in_meeting_room_table_1_true_routine"
                 }
             ]
         },
@@ -485,6 +543,18 @@
                     "target": "printer_1"
                 },
                 {
+                    "type": "evaluate_trigger",
+                    "sync_time": "0.1",
+                    "trigger": "big_meeting_agenda_1_in_printer_1_slot_check",
+                    "pass_action": "bind_juan_to_printer_1_big_meeting_agenda_1_true_routine_action",
+                    "fail_action": "bind_juan_to_juan_double_decrement_mood_routine_action"
+                }
+            ]
+        },
+        {
+            "name": "printer_1_big_meeting_agenda_1_true_routine",
+            "tasks": [
+                {
                     "type": "behavior",
                     "sync_time": "10.0",
                     "behavior": "pick_up",
@@ -505,25 +575,13 @@
                 {
                     "type": "execute_action",
                     "sync_time": "0.1",
-                    "action": "bind_juan_to_refrigerator_1_routine_action"
+                    "action": "bind_juan_to_meeting_room_table_1_routine_action"
                 }
             ]
         },
-        {
-            "name": "refrigerator_1_routine",
+                {
+            "name": "juan_double_decrement_mood_routine",
             "tasks": [
-                {
-                    "type": "behavior",
-                    "sync_time": "0.1",
-                    "behavior": "move_to",
-                    "target": "refrigerator_1"
-                },
-                {
-                    "type": "behavior",
-                    "sync_time": "20.0",
-                    "behavior": "pick_up",
-                    "target": "meeting_food_1"
-                },
                 {
                     "type": "execute_action",
                     "sync_time": "0.1",
@@ -531,9 +589,48 @@
                 },
                 {
                     "type": "execute_action",
-                    "sync_time": "20.0",
-                    "action": "bind_juan_to_meeting_room_routine_action"
+                    "sync_time": "0.1",
+                    "action": "decrement_mood_juan_action"
                 }
+            ]
+        },
+        {
+            "name": "meeting_room_table_1_routine",
+            "tasks": [
+                {
+                    "type": "behavior",
+                    "sync_time": "0.1",
+                    "behavior": "move_to",
+                    "target": "meeting_room_table_1"
+                },
+                {
+                    "type": "evaluate_trigger",
+                    "sync_time": "0.1",
+                    "trigger": "meeting_food_1_in_meeting_room_table_1_slot_check",
+                    "pass_action": "bind_juan_to_meeting_food_1_in_meeting_room_table_1_true_routine_action",
+                    "fail_action": "bind_juan_to_juan_double_decrement_mood_routine_action"
+                }
+            ]
+        },
+        {
+            "name": "meeting_food_1_in_meeting_room_table_1_true_routine",
+            "tasks": [
+            {
+                "type": "behavior",
+                "sync_time": "20.0",
+                "behavior": "pick_up",
+                "target": "meeting_food_1"
+            },
+            {
+                "type": "execute_action",
+                "sync_time": "0.1",
+                "action": "decrement_mood_juan_action"
+            },
+            {
+                "type": "execute_action",
+                "sync_time": "20.0",
+                "action": "bind_juan_to_meeting_room_routine_action"
+            }
             ]
         },
         {

--- a/Source/Atj/data/mvp_scenario.json
+++ b/Source/Atj/data/mvp_scenario.json
@@ -150,9 +150,6 @@
                     "item": "big_meeting_agenda_1",
                     "object": "printer_1"
                 }
-            ],
-            "actions": [
-                "end_game_failure_action"
             ]
         },
         {
@@ -164,9 +161,17 @@
                     "item": "meeting_food_1",
                     "object": "meeting_room_table_1"
                 }
-            ],
-            "actions": [
-                "end_game_failure_action"
+            ]
+        },
+        {
+            "name": "zaks_breakfast_1_in_refrigerator_1_slot_check",
+            "always_evaluate": false,
+            "all_of": [
+                {
+                    "type": "item_in_object_slot_check",
+                    "item": "zaks_breakfast_1",
+                    "object": "refrigerator_1"
+                }
             ]
         }
     ],
@@ -283,6 +288,46 @@
                     "type": "bind_npc",
                     "npc": "zak",
                     "routine": "zaks_desk_1_breakfast_routine"
+                }
+            ]
+        },
+        {
+            "name": "bind_zak_to_zaks_breakfast_1_in_refrigerator_1_true_routine_action",
+            "signals": [
+                {
+                    "type": "bind_npc",
+                    "npc": "zak",
+                    "routine": "zaks_breakfast_1_in_refrigerator_1_true_routine"
+                }
+            ]
+        },
+        {
+            "name": "bind_zak_to_zaks_breakfast_1_in_refrigerator_1_false_routine_action",
+            "signals": [
+                {
+                    "type": "bind_npc",
+                    "npc": "zak",
+                    "routine": "zaks_breakfast_1_in_refrigerator_1_false_routine"
+                }
+            ]
+        },
+        {
+            "name": "bind_zak_to_crossword_puzzle_1_in_reception_desk_1_true_routine_action",
+            "signals": [
+                {
+                    "type": "bind_npc",
+                    "npc": "zak",
+                    "routine": "crossword_puzzle_1_in_reception_desk_1_true_routine"
+                }
+            ]
+        },
+        {
+            "name": "bind_zak_to_zak_double_decrement_routine_action",
+            "signals": [
+                {
+                    "type": "bind_npc",
+                    "npc": "zak",
+                    "routine": "zak_double_decrement_routine"
                 }
             ]
         },
@@ -579,7 +624,7 @@
                 }
             ]
         },
-                {
+        {
             "name": "juan_double_decrement_mood_routine",
             "tasks": [
                 {
@@ -615,22 +660,22 @@
         {
             "name": "meeting_food_1_in_meeting_room_table_1_true_routine",
             "tasks": [
-            {
-                "type": "behavior",
-                "sync_time": "20.0",
-                "behavior": "pick_up",
-                "target": "meeting_food_1"
-            },
-            {
-                "type": "execute_action",
-                "sync_time": "0.1",
-                "action": "decrement_mood_juan_action"
-            },
-            {
-                "type": "execute_action",
-                "sync_time": "20.0",
-                "action": "bind_juan_to_meeting_room_routine_action"
-            }
+                {
+                    "type": "behavior",
+                    "sync_time": "20.0",
+                    "behavior": "pick_up",
+                    "target": "meeting_food_1"
+                },
+                {
+                    "type": "execute_action",
+                    "sync_time": "0.1",
+                    "action": "decrement_mood_juan_action"
+                },
+                {
+                    "type": "execute_action",
+                    "sync_time": "20.0",
+                    "action": "bind_juan_to_meeting_room_routine_action"
+                }
             ]
         },
         {
@@ -711,6 +756,18 @@
                     "target": "refrigerator_1"
                 },
                 {
+                    "type": "evaluate_trigger",
+                    "sync_time": "0.1",
+                    "trigger": "zaks_breakfast_1_in_refrigerator_1_slot_check",
+                    "pass_action": "bind_zak_to_zaks_breakfast_1_in_refrigerator_1_true_routine_action",
+                    "fail_action": "bind_zak_to_zaks_breakfast_1_in_refrigerator_1_false_routine_action"
+                }
+            ]
+        },
+        {
+            "name": "zaks_breakfast_1_in_refrigerator_1_true_routine",
+            "tasks": [
+                {
                     "type": "behavior",
                     "sync_time": "20.0",
                     "behavior": "pick_up",
@@ -735,6 +792,16 @@
                 {
                     "type": "execute_action",
                     "sync_time": "30.0",
+                    "action": "bind_zak_to_zaks_desk_1_breakfast_routine_action"
+                }
+            ]
+        },
+        {
+            "name": "zaks_breakfast_1_in_refrigerator_1_false_routine",
+            "tasks": [
+                {
+                    "type": "execute_action",
+                    "sync_time": "50.3",
                     "action": "bind_zak_to_zaks_desk_1_breakfast_routine_action"
                 }
             ]
@@ -792,6 +859,18 @@
                     "target": "reception_desk_1"
                 },
                 {
+                    "type": "evaluate_trigger",
+                    "sync_time": "0.1",
+                    "trigger": "crossword_puzzle_1_in_reception_desk_1_slot_check",
+                    "pass_action": "bind_zak_to_crossword_puzzle_1_in_reception_desk_1_true_routine_action",
+                    "fail_action": "bind_zak_to_zak_double_decrement_routine_action"
+                }
+            ]
+        },
+        {
+            "name": "crossword_puzzle_1_in_reception_desk_1_true_routine",
+            "tasks": [
+                {
                     "type": "behavior",
                     "sync_time": "10.0",
                     "behavior": "pick_up",
@@ -806,6 +885,21 @@
                 {
                     "type": "execute_action",
                     "sync_time": "20.0",
+                    "action": "decrement_mood_zak_action"
+                }
+            ]
+        },
+        {
+            "name": "zak_double_decrement_routine",
+            "tasks": [
+                {
+                    "type": "execute_action",
+                    "sync_time": "0.1",
+                    "action": "decrement_mood_zak_action"
+                },
+                {
+                    "type": "execute_action",
+                    "sync_time": "0.1",
                     "action": "decrement_mood_zak_action"
                 }
             ]


### PR DESCRIPTION
Juan & Zak will now evaluate whether an item is in an object slot before picking the item up for all objects after the initial object they start the simulation with. Sara only ever picks up her coffee cup at the start of the simulation so there is no need for her to evaluate any objects. 

I looked through all changes that I made in a before/after diff check and ensured there were no logic or spelling errors. I had missed the fact that I needed to add an item_in_object_slot_check for the crossword puzzle in the reception desk and went back to make that change. Everything else looked good to me. 