### PR TITLE
replaced zaks_desk_1 with break_room_table_1

### DIFF
--- a/Source/Atj/data/mvp_scenario.json
+++ b/Source/Atj/data/mvp_scenario.json
@@ -649,13 +649,13 @@
                     "type": "behavior",
                     "sync_time": "0.1",
                     "behavior": "move_to",
-                    "target": "zaks_desk_1"
+                    "target": "break_room_table_1"
                 },
                 {
                     "type": "behavior",
                     "sync_time": "30.0",
                     "behavior": "put_down",
-                    "target": "zaks_desk_1"
+                    "target": "break_room_table_1"
                 },
                 {
                     "type": "execute_action",


### PR DESCRIPTION
zaks_breakfast_1 and hacky_sack_club_flyer_1 were both occupying zak's desk at the same time during the simulation, causing zaks_breakfast_1 to appear on the floor. This is a quick QoL improvement to stop that from happening. I reviewed the script change, it was minor